### PR TITLE
Add a 404 page

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Not Found | Emilia Frias</title>
+    <link rel="stylesheet" href="/static/styles/main.css">
+    <link rel="icon" href="/static/images/favicon.png" type="image/png">
+</head>
+
+<body>
+    <nav class="sticky">
+        <div class="nav-content">
+            <h1 class="nav-brand">Page Not Found</h1>
+            <ul class="nav-items">
+                <li><a href="/">Home</a></li>
+                <!-- <li><a href="/about">About Me</a></li> -->
+                <li><a href="/rigging">Rigging</a></li>
+                <li><a href="/animation">Animation</a></li>
+                <li><a href="/short-films">Short Films</a></li>
+            </ul>
+        </div>
+    </nav>
+
+    <main style="display:flex; justify-content: center; align-items: center; height: 100vh;">
+        <div style="text-align:center;">
+            <p>The page you were looking for was not found</p>
+            <p><a href="/">Click here</a> to return home</p>
+        </div>
+    </main>
+    <script data-goatcounter="https://demilurii.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
+</body>
+
+</html>


### PR DESCRIPTION
Google is indexing URLs that don't exist.

For example, I found a google search result that points to `/commissions` despite the fact you don't have that page.

![image](https://github.com/Demilurii/demilurii.art/assets/21065412/14435677-3a5b-4a92-b051-f0ba8f76504c)

I think google needs a nudge to re-index your site. For now, I've added a [404](https://en.wikipedia.org/wiki/HTTP_404) page, so that next time those links are crawled, they will be marked non-existent.

Here's what the new 404 page looks like in my dev environment:
![image](https://github.com/Demilurii/demilurii.art/assets/21065412/bc49787d-cdf4-4b9d-b8e6-befb4a680a36)

We can modify the exact content of this page later
